### PR TITLE
smaller improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Exported backup files will be compressed.
     backup mode = incremental
     check mode = no
 
+### Backup all images
+
+Using `images = *` creates a backup of all images in the pool.
+
 ## Restoring an incremental backup
 
 Restore the base export (full):

--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@
 A tool to take backups of ceph rados block images that works in two backup modes (see [Sample configuration](#sample-configuration)):
 
  * Incremental: incremental backups within a given backup window based on rbd snapshots
- * Full: full image exports without snapshots
+ * Full: full image exports based on a temporary snapshot
 
 **Note on consistency**: this tool makes snapshots of rbd images without any awareness of the status of the filesystem they contain. Be aware of the consistency limits of rbd snapshots: http://docs.ceph.com/docs/hammer/rbd/rbd-snapshot/.
-Also, since "Full" mode doesn't use snapshots, backups of *live* images in "Full" mode are not consistent (on the contrary, "Incremental" mode always uses snapshots).
 
 ## Building
 

--- a/cephbackup/ceph_backup.py
+++ b/cephbackup/ceph_backup.py
@@ -18,7 +18,8 @@ class CephFullBackup(object):
             # rbd export test@snap testexport
     '''
 
-    TIMESTAMP_FMT = 'UTC%Y%m%dT%H%M%S'
+    PREFIX = 'BACKUP'
+    TIMESTAMP_FMT = '{}UTC%Y%m%dT%H%M%S'.format(PREFIX)
     FULL_BACKUP_SUFFIX = '.full'
     DIFF_BACKUP_SUFFIX = '.diff_from'
     COMPRESSED_BACKUP_SUFFIX = '.tar.gz'
@@ -69,10 +70,16 @@ class CephFullBackup(object):
         Each snapshot is represented like the following:
         {'id': 40L, 'name': u'UTC20161117T164401', 'size': 21474836480L}
         '''
+
+        prefix_length = len(CephFullBackup.PREFIX)
+
         image = rbd.Image(self._ceph_ioctx, imagename)
         snapshots = []
         for snapshot in image.list_snaps():
-            snapshots.append(snapshot)
+            # only return backup snapshots
+            if snapshot.get('name')[0:prefix_length] == CephFullBackup.PREFIX:
+                snapshots.append(snapshot)
+
         return snapshots
 
     def _get_oldest_snapshot(self, imagename):

--- a/cephbackup/ceph_backup.py
+++ b/cephbackup/ceph_backup.py
@@ -46,6 +46,10 @@ class CephFullBackup(object):
         self._ceph_ioctx = cluster.open_ioctx(pool)
         self._ceph_rbd = rbd.RBD()
 
+        # support wildcard for images
+        if len(self._images) == 1 and self._images[0] == '*':
+            self._images = self._get_images()
+
     def print_overview(self):
         print "Images to backup:"
         for image in self._images:
@@ -73,6 +77,13 @@ class CephFullBackup(object):
 
             # Delete Snapshot after export
             self._delete_snapshot(image, timestamp)
+
+    def _get_images(self):
+        '''
+        Fetches a list of all images inside the pool.
+        '''
+
+        return self._ceph_rbd.list(self._ceph_ioctx)
 
     def _get_snapshots(self, imagename):
         '''

--- a/cephbackup/ceph_backup.py
+++ b/cephbackup/ceph_backup.py
@@ -62,7 +62,17 @@ class CephFullBackup(object):
         if self._check_mode:
             print "Running in check mode: backup commands will just be printed and not executed"
         for image in self._images:
-            self._export_image_or_snapshot(image, image, base=None)
+            timestamp = self._get_timestamp_str()
+            fullsnapshotname = CephFullBackup._get_full_snapshot_name(image, timestamp)
+
+            # Take snapshot
+            self._create_snapshot(image, timestamp)
+
+            # Export image
+            self._export_image_or_snapshot(fullsnapshotname, image, base=None)
+
+            # Delete Snapshot after export
+            self._delete_snapshot(image, timestamp)
 
     def _get_snapshots(self, imagename):
         '''


### PR DESCRIPTION
I made some smaller changes, you might be interested in:

- create snapshot before full backup and delete it afterwards. this should ensure a minimum of consistency even the image is live.
- export all images of the pool using * wildcard
- ignore custom snapshots not made by this script