### PR TITLE
Restrict format of export filename

### DIFF
--- a/cephbackup/ceph_backup.py
+++ b/cephbackup/ceph_backup.py
@@ -298,7 +298,7 @@ class CephFullBackup(object):
         base_backup_folder = os.path.join(self._backup_dest, self._pool, image)
         date_ref = self._get_date_from_timestamp_str(timestamp)
         for export in os.listdir(base_backup_folder):
-            m = re.match('{}@(.*?)[{}|{}]'.format(image, CephFullBackup.DIFF_BACKUP_SUFFIX, CephFullBackup.FULL_BACKUP_SUFFIX), export)
+            m = re.match('{}@({}.*?)[{}|{}]'.format(image, self.PREFIX, CephFullBackup.DIFF_BACKUP_SUFFIX, CephFullBackup.FULL_BACKUP_SUFFIX), export)
             if not m:
                 print "WARNING: unexpected file in {base}: {fn}".format(base=base_backup_folder, fn=export)
                 continue


### PR DESCRIPTION
The regex to validate filenames now contains the prefix.
This is to be backward compatible with backups that were done
before the prefix was introduced.
Those exports taken without the prefix will now be excluded when
found in the backup path, instead of causing an error.