### PR TITLE
Add convert_to_qcow2 option

### DIFF
--- a/ceph-backup.cfg
+++ b/ceph-backup.cfg
@@ -4,6 +4,7 @@ window unit = days
 destination directory = /tmp/
 images = deleteme,test
 compress = yes
+convert to qcow2 = no
 ceph config = /etc/ceph/ceph.conf
 backup mode = incremental
 check mode = no

--- a/cephbackup/settings.py
+++ b/cephbackup/settings.py
@@ -33,10 +33,11 @@ class Settings(object):
             conf_file = self.getsetting(section, 'ceph config')
             check_mode = bool(strtobool(self.getsetting(section, 'check mode')))
             compress_mode = bool(strtobool(self.getsetting(section, 'compress')))
+            convert_to_qcow2 = bool(strtobool(self.getsetting(section, 'convert to qcow2')))
             window_size = int(self.getsetting(section, 'window size'))
             window_unit = self.getsetting(section, 'window unit')
             backup_mode = self.getsetting(section, 'backup mode')
-            cb = CephFullBackup(section, images, backup_dest, conf_file, check_mode, compress_mode, window_size, window_unit)
+            cb = CephFullBackup(section, images, backup_dest, conf_file, check_mode, compress_mode, convert_to_qcow2, window_size, window_unit)
             if backup_mode == 'full':
                 print "Full ceph backup"
                 cb.print_overview()


### PR DESCRIPTION
As exported rbd is raw format which is sparsed with zeros, it is
generically very large. The convert_to_qcow2 option will convert the
raw disk to qcow2 format to reduce the size, the default is False.